### PR TITLE
Sticker showcase

### DIFF
--- a/Build-StickerShowcase.ps1
+++ b/Build-StickerShowcase.ps1
@@ -1,0 +1,12 @@
+﻿[CmdletBinding()]
+param (
+    $Path = "$PSScriptRoot\SHOWCASE.md"
+)
+New-Item $Path -Force
+$finalDesigns = Get-ChildItem -Recurse -Include *-final.png
+foreach ($design in $finalDesigns) {
+    $directory = $ExecutionContext.SessionState.Path.NormalizeRelativePath($design.PSParentPath, $PSScriptRoot)
+    $image = $ExecutionContext.SessionState.Path.NormalizeRelativePath($design.PSPath, $PSScriptRoot)
+    $file = $design.BaseName -replace "-final", ""
+    Add-Content -Value "${file}:<a href=`"$directory`"><img src=`"$image`" width=`"25%`"></a>`r`n" -Path $Path
+}

--- a/Build-StickerShowcase.ps1
+++ b/Build-StickerShowcase.ps1
@@ -2,7 +2,14 @@
 param (
     $Path = "$PSScriptRoot\SHOWCASE.md"
 )
+$preamble = @"
+# Sticker Showcase
+
+| Sticker Name | Sticker sample |
+| ------------ | -------------- |
+"@
 New-Item $Path -Force
+Add-Content -Value $preamble -Path $Path
 $finalDesigns = Get-ChildItem -Recurse -Include *-final.png
 foreach ($design in $finalDesigns) {
     $directory = $ExecutionContext.SessionState.Path.NormalizeRelativePath($design.PSParentPath, $PSScriptRoot)

--- a/Build-StickerShowcase.ps1
+++ b/Build-StickerShowcase.ps1
@@ -15,5 +15,5 @@ foreach ($design in $finalDesigns) {
     $directory = $ExecutionContext.SessionState.Path.NormalizeRelativePath($design.PSParentPath, $PSScriptRoot)
     $image = $ExecutionContext.SessionState.Path.NormalizeRelativePath($design.PSPath, $PSScriptRoot)
     $file = $design.BaseName -replace "-final", ""
-    Add-Content -Value "${file}:<a href=`"$directory`"><img src=`"$image`" width=`"25%`"></a>`r`n" -Path $Path
+    Add-Content -Value "|${file}|<a href=`"$directory`"><img src=`"$image`" width=`"25%`"></a>|" -Path $Path
 }

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,7 +1,7 @@
 # Sticker Showcase
 
 | Sticker Name | Sticker sample |
-| ============ | ============== |
+| ------------ | -------------- |
 |back-to-the-shell|<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>|
 |bridge-for-life|<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>|
 |dev-ooops|<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>|

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -2,18 +2,33 @@
 
 | Sticker Name | Sticker sample |
 | ------------ | -------------- |
-|back-to-the-shell|<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>|
-|bridge-for-life|<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>|
-|dev-ooops|<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>|
-|pwsh-hex|<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>|
-|hire-joel|<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>|
-|markekraus|<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>|
-|posh365|<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>|
-|psgrafana|<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>|
-|koan-monk|<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>|
-|ps-live-avatar|<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>|
-|ps-live|<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>|
-|pssa|<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>|
-|powershell-or-gtfo|<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>|
-|pwsh-or-gtfo|<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>|
-|vscode-pwsh-miami|<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>|
+back-to-the-shell:<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>
+
+bridge-for-life:<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>
+
+dev-ooops:<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>
+
+pwsh-hex:<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>
+
+hire-joel:<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>
+
+markekraus:<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>
+
+posh365:<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>
+
+psgrafana:<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>
+
+koan-monk:<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>
+
+ps-live-avatar:<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>
+
+ps-live:<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>
+
+pssa:<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>
+
+powershell-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>
+
+pwsh-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>
+
+vscode-pwsh-miami:<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>
+

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -2,33 +2,18 @@
 
 | Sticker Name | Sticker sample |
 | ------------ | -------------- |
-back-to-the-shell:<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>
-
-bridge-for-life:<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>
-
-dev-ooops:<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>
-
-pwsh-hex:<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>
-
-hire-joel:<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>
-
-markekraus:<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>
-
-posh365:<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>
-
-psgrafana:<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>
-
-koan-monk:<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>
-
-ps-live-avatar:<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>
-
-ps-live:<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>
-
-pssa:<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>
-
-powershell-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>
-
-pwsh-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>
-
-vscode-pwsh-miami:<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>
-
+|back-to-the-shell|<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>|
+|bridge-for-life|<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>|
+|dev-ooops|<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>|
+|pwsh-hex|<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>|
+|hire-joel|<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>|
+|markekraus|<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>|
+|posh365|<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>|
+|psgrafana|<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>|
+|koan-monk|<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>|
+|ps-live-avatar|<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>|
+|ps-live|<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>|
+|pssa|<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>|
+|powershell-or-gtfo|<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>|
+|pwsh-or-gtfo|<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>|
+|vscode-pwsh-miami|<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>|

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,0 +1,30 @@
+back-to-the-shell:<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>
+
+bridge-for-life:<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>
+
+dev-ooops:<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>
+
+pwsh-hex:<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>
+
+hire-joel:<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>
+
+markekraus:<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>
+
+posh365:<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>
+
+psgrafana:<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>
+
+koan-monk:<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>
+
+ps-live-avatar:<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>
+
+ps-live:<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>
+
+pssa:<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>
+
+powershell-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>
+
+pwsh-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>
+
+vscode-pwsh-miami:<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>
+

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,30 +1,19 @@
-back-to-the-shell:<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>
+# Sticker Showcase
 
-bridge-for-life:<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>
-
-dev-ooops:<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>
-
-pwsh-hex:<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>
-
-hire-joel:<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>
-
-markekraus:<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>
-
-posh365:<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>
-
-psgrafana:<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>
-
-koan-monk:<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>
-
-ps-live-avatar:<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>
-
-ps-live:<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>
-
-pssa:<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>
-
-powershell-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>
-
-pwsh-or-gtfo:<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>
-
-vscode-pwsh-miami:<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>
-
+| Sticker Name | Sticker sample |
+| ============ | ============== |
+|back-to-the-shell|<a href="back-to-the-shell"><img src="back-to-the-shell\back-to-the-shell-final.png" width="25%"></a>|
+|bridge-for-life|<a href="bridge-for-life"><img src="bridge-for-life\bridge-for-life-final.png" width="25%"></a>|
+|dev-ooops|<a href="dev-ooops"><img src="dev-ooops\dev-ooops-final.png" width="25%"></a>|
+|pwsh-hex|<a href="hex-pwsh-avatar"><img src="hex-pwsh-avatar\pwsh-hex-final.png" width="25%"></a>|
+|hire-joel|<a href="hire-joel"><img src="hire-joel\hire-joel-final.png" width="25%"></a>|
+|markekraus|<a href="markekraus"><img src="markekraus\markekraus-final.png" width="25%"></a>|
+|posh365|<a href="posh365"><img src="posh365\posh365-final.png" width="25%"></a>|
+|psgrafana|<a href="psgrafana"><img src="psgrafana\psgrafana-final.png" width="25%"></a>|
+|koan-monk|<a href="pskoans"><img src="pskoans\koan-monk-final.png" width="25%"></a>|
+|ps-live-avatar|<a href="ps-live"><img src="ps-live\ps-live-avatar-final.png" width="25%"></a>|
+|ps-live|<a href="ps-live"><img src="ps-live\ps-live-final.png" width="25%"></a>|
+|pssa|<a href="psscriptanalyzer"><img src="psscriptanalyzer\pssa-final.png" width="25%"></a>|
+|powershell-or-gtfo|<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\powershell-or-gtfo-final.png" width="25%"></a>|
+|pwsh-or-gtfo|<a href="pwsh-or-gtfo"><img src="pwsh-or-gtfo\pwsh-or-gtfo-final.png" width="25%"></a>|
+|vscode-pwsh-miami|<a href="vscode-pwsh-miami"><img src="vscode-pwsh-miami\vscode-pwsh-miami-final.png" width="25%"></a>|


### PR DESCRIPTION
Fixes #18 

This adds a Build-StickerShowcase.ps1 file that recreates `SHOWCASE.md` with all `png` files that end with `-final.png`

The md file is currently rather simplistic, but it could be easily expanded.

To complete the showcase, the directories that don't currently have "final" pngs will need to have them added.